### PR TITLE
Update latest event video 

### DIFF
--- a/_videos/chicagoruby_adler_planetarium_build_or_buy.md
+++ b/_videos/chicagoruby_adler_planetarium_build_or_buy.md
@@ -1,0 +1,14 @@
+---
+title: Build or Buy? | Does Ruby Love Me Back?
+date: 2025-03-05 00:00:00 Z
+youtube_id: tA8Omrq0Px4
+event: Adler Planetarium
+teaser: Two talks exploring whether to build or buy your next solution and what makes Ruby uniquely expressive.
+speaker: Ifat Ribon and Noel Rappin
+speaker_bio: >
+  Ifat Ribon is a web developer based in Chicago, Illinois. She builds custom web applications for startups and speaks on both technical and human aspects of development. 
+
+  Noel Rappin is a Staff Engineer at Chime Financial, former host of the *Tech Done Right* podcast, and author of multiple technical books, including *Programming Ruby 3.3*.
+---
+
+Two concise talks from our March 2025 meetup at the Adler Planetarium: a 5-factor “Build or Buy?” framework and a celebration of Ruby’s expressiveness.  

--- a/_videos/github-ui-lesson-and-productivity-with-gen-ai.md
+++ b/_videos/github-ui-lesson-and-productivity-with-gen-ai.md
@@ -1,0 +1,12 @@
+---
+title: GitHub UI Lesson by Joel Hawksley | Productivity with GenAI by Chelsea Troy
+date: 2025-05-07 00:00:00 Z
+youtube_id: SQXIrKHpv8A?si=yfnWSVg2U2Pv7afC
+event: Avant Chicago
+teaser: The presentations cover strategies to build and maintain scalable, accessible Rails UI systems, and a practical framework for harnessing GenAI’s productivity benefits. 
+speaker: Joel Hawksley and Chelsea Troy
+speaker_bio: Joel Hawksley is a Staff Engineer at GitHub, creator of ViewComponent, and a leader in frontend architecture for Rails apps. Chelsea Troy is a software engineer, educator, and advocate for thoughtful, intentional development practices. 
+
+---
+
+GitHub’s Joel Hawksley reveals five years of scaling UI in Rails apps, while Mozilla’s Chelsea Troy cuts through the GenAI hype to show its true impact on developer productivity.

--- a/_videos/github-ui-lesson-and-productivity-with-gen-ai.md
+++ b/_videos/github-ui-lesson-and-productivity-with-gen-ai.md
@@ -1,5 +1,5 @@
 ---
-title: GitHub UI Lesson by Joel Hawksley | Productivity with GenAI by Chelsea Troy
+title: GitHub UI Lesson | Productivity with GenAI
 date: 2025-05-07 00:00:00 Z
 youtube_id: SQXIrKHpv8A
 event: Avant Chicago
@@ -10,3 +10,5 @@ speaker_bio: Joel Hawksley is a Staff Engineer at GitHub, creator of ViewCompone
 ---
 
 GitHub’s Joel Hawksley reveals five years of scaling UI in Rails apps, while Mozilla’s Chelsea Troy cuts through the GenAI hype to show its true impact on developer productivity.
+
+///unstage file

--- a/_videos/github-ui-lesson-and-productivity-with-gen-ai.md
+++ b/_videos/github-ui-lesson-and-productivity-with-gen-ai.md
@@ -10,5 +10,3 @@ speaker_bio: Joel Hawksley is a Staff Engineer at GitHub, creator of ViewCompone
 ---
 
 GitHub’s Joel Hawksley reveals five years of scaling UI in Rails apps, while Mozilla’s Chelsea Troy cuts through the GenAI hype to show its true impact on developer productivity.
-
-///unstage file

--- a/_videos/github-ui-lesson-and-productivity-with-gen-ai.md
+++ b/_videos/github-ui-lesson-and-productivity-with-gen-ai.md
@@ -1,7 +1,7 @@
 ---
 title: GitHub UI Lesson by Joel Hawksley | Productivity with GenAI by Chelsea Troy
 date: 2025-05-07 00:00:00 Z
-youtube_id: SQXIrKHpv8A?si=yfnWSVg2U2Pv7afC
+youtube_id: SQXIrKHpv8A
 event: Avant Chicago
 teaser: The presentations cover strategies to build and maintain scalable, accessible Rails UI systems, and a practical framework for harnessing GenAI’s productivity benefits. 
 speaker: Joel Hawksley and Chelsea Troy

--- a/_videos/modular_monoliths_in_rails_lessons_from_6_years_at_scale.md
+++ b/_videos/modular_monoliths_in_rails_lessons_from_6_years_at_scale.md
@@ -1,5 +1,5 @@
 ---
-title: Modular Monoliths in Rails - Lessons from 6+ Years at Scale
+title: "Modular Monoliths in Rails: Lessons from 6+ Years at Scale"
 date: 2025-04-04 00:00:00 Z
 youtube_id: Pm2qC7__MZQ
 event: AlphaSense

--- a/_videos/modular_monoliths_in_rails_lessons_from_6_years_at_scale.md
+++ b/_videos/modular_monoliths_in_rails_lessons_from_6_years_at_scale.md
@@ -1,0 +1,12 @@
+---
+title: Modular Monoliths in Rails - Lessons from 6+ Years at Scale
+date: 2025-04-04 00:00:00 Z
+youtube_id: Pm2qC7__MZQ
+event: AlphaSense
+teaser: How do you scale a Rails app without falling into the trap of microservices? 
+speaker: Lionel Barrow
+speaker_bio: Lionel Barrow is a former Head of Engineering at Tegus, clinical professor at UChicago MPCS, and advocate for long-term sustainable architecture in Rails.
+---
+
+A deep architectural dive into sustaining and scaling a modular monolith in Rails, with hard-won lessons from six years at Tegus (now AlphaSense).
+


### PR DESCRIPTION
This update added new video metadata for latest event video display

[Link to issue](https://github.com/chicagoruby/chicagoruby-website/issues/9)

**Change**

<img width="700" height: auto alt="Screenshot 2025-06-06 at 18 15 53" src="https://github.com/user-attachments/assets/8cfe9a61-4f08-439d-8a7b-b606bed4b95b" />
<img width="700" height: auto alt="Screenshot 2025-06-06 at 18 15 53" src="https://github.com/user-attachments/assets/410617d5-224d-4f71-8c85-e3ad3ee58ed7" />


