### PR TITLE
Update latest event videos #14 and readme instructions #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,14 @@ This site has two Jekyll Data Files, stored in YAML format.
 
 * **Supporter Logos:** 400 pixels wide
 * **Organizer Photos:** 400 pixels squared
+
+## Setup instructions
+
+* install Ruby:
+  as of January 2026 the earliest version of Ruby still mantained is 3.2.2
+* install Jekyll:
+  gem install jekyll bundler
+* run the website locally: 
+  bundle exec jekyll serve
+* browse to: 
+  http://localhost:4000

--- a/README.md
+++ b/README.md
@@ -22,11 +22,15 @@ This site has two Jekyll Data Files, stored in YAML format.
 
 ## Setup instructions
 
-* install Ruby:
+* Install Ruby:
+
   as of January 2026 the earliest version of Ruby still mantained is 3.2.2
-* install Jekyll:
-  gem install jekyll bundler
+* Install Jekyll:
+
+  `gem install jekyll bundler`
 * run the website locally: 
-  bundle exec jekyll serve
-* browse to: 
+
+  `bundle exec jekyll serve`
+* Browse to: 
+
   http://localhost:4000

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ This site has two Jekyll Data Files, stored in YAML format.
 
 * Install Ruby:
 
-  as of January 2026 the earliest version of Ruby still mantained is 3.2.2
+  As of January 2026 the earliest version of Ruby still maintained is 3.2.2, I was not able to install an earlier version. Jekyll and this project will work with 3.2.2.
 * Install Jekyll:
 
   `gem install jekyll bundler`
 * Run the website locally: 
 
-  `bundle exec jekyll serve`
+  `jekyll serve`
 * Browse to: 
 
   http://localhost:4000

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This site has two Jekyll Data Files, stored in YAML format.
 * Install Jekyll:
 
   `gem install jekyll bundler`
-* run the website locally: 
+* Run the website locally: 
 
   `bundle exec jekyll serve`
 * Browse to: 

--- a/_videos/domain-driven-design-june2025.md
+++ b/_videos/domain-driven-design-june2025.md
@@ -1,0 +1,16 @@
+---
+title:  Real-world strategies for scaling Rails applications | Domain Driven Design 
+date: 2025-06-04 00:00:00 Z
+youtube_id: t9tXHMcvIk4
+event: Chime Chicago
+teaser: This month’s Ruby meetup, hosted at Chime Chicago, features two talks focused on Domain Driven Design by Andrzej Krzywda, Alan Ridlehoover and Fito von Zastrow. 
+speaker: Andrzej Krzywda, Alan Ridlehoover and Fito von Zastrow
+speaker_bio: Andrzej Krzywda is the founder of Arkency, creator of the Rails Architect Masterclass, and an experienced Rails consultant focused on large-scale applications. Alan Ridlehoover leads the Dashboard Platform Engineering teams for Cisco’s cloud networking platform. Fito von Zastrow is a staff software engineer focused on improving code quality and maintainability at Cisco Meraki.
+---
+
+
+What does it take to keep a massive Rails monolith maintainable without a total rewrite?
+Andrzej shares real-world strategies for scaling Rails applications while keeping complexity under control as your team and codebase grow.
+
+How do you evolve a Rails monolith with over 4 million lines of code?
+Alan and Fito share Cisco Meraki’s approach to decoupling business logic from Rails constructs, enabling their teams to handle rapid growth and complexity at scale.

--- a/_videos/job-testing-and-wrangle-domain-complexity-with-foobara-august2025.md
+++ b/_videos/job-testing-and-wrangle-domain-complexity-with-foobara-august2025.md
@@ -5,7 +5,7 @@ youtube_id: xu09IkchT_I
 event: Workforce Chicago
 teaser: The August 2025 Chicago Ruby meetup features two speakers who have developed tools designed to help engineers build better-tested applications and more adaptive systems.
 speaker: Stephen Margheim and Miles Georgi
-speaker_bio: Stephen Margheim is a Principal Engineer at Impruvon Health. Miles Georgi is a software engineer and creator of Foobara, framework that is command-centric and discoverable.
+speaker_bio: Stephen Margheim is a principal engineer at Impruvon Health. Miles Georgi is a software engineer and creator of Foobara, a framework that is command-centric and discoverable.
 ---
 
 Stephen explores what makes background job testing fundamentally different from other kinds of tests, and introduces Chaotic Job, a gem he built to simulate transient failures, retry behavior, and production-like test conditions.

--- a/_videos/job-testing-and-wrangle-domain-complexity-with-foobara-august2025.md
+++ b/_videos/job-testing-and-wrangle-domain-complexity-with-foobara-august2025.md
@@ -1,0 +1,13 @@
+---
+title: Job Testing | Wrangle Domain Complexity with Foobara
+date: 2025-08-07 00:00:00 Z
+youtube_id: xu09IkchT_I
+event: Workforce Chicago
+teaser: The August 2025 Chicago Ruby meetup features two speakers who have developed tools designed to help engineers build better-tested applications and more adaptive systems.
+speaker: Stephen Margheim and Miles Georgi
+speaker_bio: Stephen Margheim is a Principal Engineer at Impruvon Health. Miles Georgi is a software engineer and creator of Foobara, framework that is command-centric and discoverable.
+---
+
+Stephen explores what makes background job testing fundamentally different from other kinds of tests, and introduces Chaotic Job, a gem he built to simulate transient failures, retry behavior, and production-like test conditions.
+
+Miles introduces Foobara, a Ruby framework built around command-centric and discoverable systems. Drawing on lessons from years of wrangling complex domains (from mortgages to EV benefits to solar panels), he shares why commands, not controllers, should be your core abstraction — and how discoverability, RPC, and LLMs can help teams build more adaptive systems.

--- a/_videos/perfect-data-isn’t-realistic-October2025.md
+++ b/_videos/perfect-data-isn’t-realistic-October2025.md
@@ -1,0 +1,15 @@
+---
+title: Perfect Data Isn’t Realistic | Single Schema With UUIDs
+date: 2025-10-01 00:00:00 Z
+youtube_id: I0UOJYxOcBA
+event: Prism Spaces Chicago
+teaser: This month’s speakers focus on data, featuring Peter’s open-source gem Recheck and how Prarthana’s team at NexHealth rebuilt their healthtech DB around row-based multitenancy using UUIDs.
+speaker: Peter Bhat Harkins and Prarthana Shiva
+speaker_bio: Peter Bhat is a software engineer who created Recheck, a gem that detects data anomalies in production databases before they become customer-facing problems. Prarthana Shiva is a software engineer at NexHealth, with extensive experience in backend development and technical architecture.
+---
+
+
+What if perfect data isn’t realistic — and that’s okay?
+Peter showed how even “safe” Rails code can persist impossible records, from race conditions to forgotten migrations. His open-source gem Recheck treats data queries like tests, helping you detect invalid rows in production — before users notice.
+
+When thousands of per-tenant schemas became a scaling nightmare, Prarthana’s team at NexHealth rebuilt their healthtech DB around row-based multitenancy using UUIDs. The transition? Like changing a wing on a flying aircraft.

--- a/_videos/reusable-jSON-schemas-november2025.md
+++ b/_videos/reusable-jSON-schemas-november2025.md
@@ -3,7 +3,7 @@ title: Reusable JSON Schemas | Hotwire Your UX
 date: 2025-11-04 00:00:00 Z
 youtube_id: aeLcOW4Cfe4
 event: Cisco Chicago
-teaser: This month’s speakers focus on leveraging schemas across the entire Rails stack and on how Hotwire delivers a better user experience
+teaser: This month’s speakers focus on leveraging schemas across the entire Rails stack and on how Hotwire delivers a better user experience.
 speaker: Andy Andrea and Patrick McSweeny
 speaker_bio: Andy Andreea is a lead software engineer at Panorama Education. Patrick McSweeny is a product engineer at William Davidson Institute. 
 ---

--- a/_videos/reusable-jSON-schemas.md
+++ b/_videos/reusable-jSON-schemas.md
@@ -1,0 +1,13 @@
+---
+title: Reusable JSON Schemas | Hotwire Your UX
+date: 2025-11-04 00:00:00 Z
+youtube_id: aeLcOW4Cfe4
+event: Cisco Chicago
+teaser: This month’s speakers focus on leveraging schemas across the entire Rails stack and on how Hotwire delivers a better user experience
+speaker: Andy Andrea and Patrick McSweeny
+speaker_bio: Andy Andreea is a lead software engineer at Panorama Education. Patrick McSweeny is a product engineer at William Davidson Institute. 
+---
+
+Andy Andrea presents an innovative approach to leveraging schemas throughout your entire Rails stack. Working in ed tech for the past few years, Andy demonstrates how a single schema concept can transform from database migrations into a powerful multi-purpose tool across your application.
+
+Patrick McSweeney explores how Hotwire enables rich, interactive web experiences while maintaining the simplicity, accessibility, and performance benefits of server-side rendering. Drawing on his experience since the late 1990s, Patrick provides historical context and practical insights into modern web development.

--- a/_videos/zen-automation-september2025.md
+++ b/_videos/zen-automation-september2025.md
@@ -1,0 +1,13 @@
+---
+title: Zen Automation | Better Team Organization
+date: 2025-09-04 00:00:00 Z
+youtube_id: _RsW2DYGWB8
+event: Beyond Finance Chicago
+teaser: This month’s speakers explore two core pillars of a software company- building better, simpler automation and improving organizational management.
+speaker: Aji Slater and Jim Remsik
+speaker_bio: Aji Slater is a software engineer at Thoughtbot. Jim Remsik is the founder of Flagrant, a human-centered software company founded in 2019. 
+---
+
+Aji shares how their team uses small, mindful automation steps to relieve frustration, reduce mental load, and make space for better work. 
+
+After two decades in consulting, Jim asks a radical question: What if doing less made your team more effective? Drawing from real-world experience scaling engineering orgs and dealing with client complexity, he lays out a framework for thoughtful restraint.


### PR DESCRIPTION
These updates added new video metadata for the last 5 meetups, as well as adding README setup instructions. 

Link to [issue 14](https://github.com/chicagoruby/chicagoruby-website/issues/14) - video medadata. 

Link to [issue 17 ](https://github.com/chicagoruby/chicagoruby-website/issues/17) - README instructions.

Changes:

<img width="1306" height="935" alt="Screenshot 2026-01-21 at 11 17 06 AM" src="https://github.com/user-attachments/assets/3af90996-3800-45d7-99d8-c79aed4a42ea" />

<img width="951" height="703" alt="readme" src="https://github.com/user-attachments/assets/69e11415-dcca-437f-a422-753813fd26dd" />
