### PR TITLE
Issue 15: Update Speaker Guidelines

### DIFF
--- a/pages/simple/guidelines.md
+++ b/pages/simple/guidelines.md
@@ -5,7 +5,9 @@ permalink: "/about/speaker-guidelines/"
 
 # Speaking at ChicagoRuby Events
 
-Would you like to speak at a ChicagoRuby meeting or [WindyCityRails](http://windycityrails.com) conference? We welcome you! Of course, we have guidelines that we ask all of our presenters to follow. The guidelines ensure that:
+Would you like to speak at a ChicagoRuby meeting? We welcome you! Of course, we
+have guidelines that we ask all of our presenters to follow. The guidelines
+ensure that:
 
 - ChicagoRuby members receive value from every presentation.
 - Speakers receive value through interaction with our members.
@@ -21,10 +23,15 @@ We want all stakeholders to benefit from ChicagoRuby: Attendees, presenters, and
 4. Your product should work on Mac OS X or Linux. It can work on Windows, too, but bear in mind that the overwhelming majority of our community is Mac-based, and enjoys being so. If your product is primarily Windows-based, chances are your product isn't a good fit for ChicagoRuby.
 5. Use high-contrast presentation slides. If you use Keynote/PowerPoint slides in your presentation, make them high-contrast. Our presentation room is brightly lit and we have no control over the lighting. Dark characters on a black background will render your presentation invisible to the audience. Black letters on a white background will give you great visibility. You can experiment with other colors if you like, but the end result should be high-contrast, or your presentation will be invisible. If you use Vim, the [:TOhtml tool](http://rayhightower.com/blog/2013/10/31/tohtml-using-vim-code-snippets-in-keynote-presentations/) will keep syntax highlighting intact as you [copy code from Vim to Keynote](http://rayhightower.com/blog/2013/10/31/tohtml-using-vim-code-snippets-in-keynote-presentations/). Other editors have similar tools.
 6. Remember your display adapter. Our projector is HDMI. You will need a [your laptop display port]-to-HDMI adapter in order to connect to the projector. It's almost funny: After putting so many hours into an outstanding presentation, many presenters forget to bring the right display adapter! It's a small detail, very easy to miss, and that's why we mention it here.
-7. We record many of our presentations on video. [Videos are shared on the web.](http://vimeo.com/chicagoruby/channels) You're welcome to use the video on your own blog or web site.
-8. Presentations last for **45 minutes**. You can do 30 minutes of speaking
-   followed by 15 minutes of Q & A, or you can use the entire 45 minutes
-   interactively. Your call!
+7. We record many of our presentations on video.
+   [Current videos](https://www.youtube.com/@chicagorubymeetups)
+   and
+   [older videos](https://vimeo.com/chicagoruby/channels)
+   are shared on the web.
+   You're welcome to use the video on your own blog or web site.
+8. Presentations can be as short as 5 minutes (like a Lightning Talk) or as long
+   as 1 hour.  We usually allot 30-45 minutes for a speaker, but if you need
+   more time, let the organizers know so that they can budget time accordingly.
 9. Additional polish. For more tips on creating a great presentation, check out John Nunemaker's [Improve Your Presentations In Under $50](http://railstips.org/blog/archives/2010/05/05/improve-your-presentations-in-under-50/) article and Inc.'s [21 Quick Tips](http://www.inc.com/geoffrey-james/how-to-fix-your-presentations-21-tips.html).
 
 ## Typical Meeting Agenda


### PR DESCRIPTION
- Remove _WindyCityRails_ link since it no longer works
  <img width="1857" height="652" alt="windy-city-rails-removal" src="https://github.com/user-attachments/assets/b9d72431-2e40-4297-929f-fcdb289322ed" />


- Reword point 7 to include links to both:
  - the current presentations on YouTube and
  - the old presentations on Vimeo
- Update point 8 to indicate new presentation duration guidelines.
  <img width="1848" height="447" alt="points-7-and-8-updated" src="https://github.com/user-attachments/assets/99e8859f-8372-41e2-8e18-be0d94a2962a" />
