### PR TITLE
Issue 22: Remove WindyCityRails links

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,13 +40,6 @@ social-image: home-2016-09-06.png
   <p>Dive deeper with more events.</p>
 
   <ul>
-    <li>
-      <a href="https://windycityrails.com">
-        {% include svg/logo-windycityrails.svg %}
-        <p>An annual gathering for all who are
-          passionate about Ruby on Rails.</p>
-      </a>
-    </li>
     <li class="supporter-columns">
       <a href="https://scna.softwarecraftsmanship.com">
         {% include svg/logo-scna.svg %}

--- a/pages/simple/resources.md
+++ b/pages/simple/resources.md
@@ -90,7 +90,6 @@ These are books I use as references. Do NOT buy Kindle editions. When you copy /
 - By far, the best resource / place to start learning ROR is with [Dave Jones, YouTube Channel](https://www.youtube.com/user/lockersoft) - Ruby on Rails 4.0 Lectures (29), Ruby Programming Lectures, Introduction to Ruby Programming (21), Ruby Programming - II (21)
 - Railscasts, Ruby on Rails Screencasts <http://railscasts.com/>
 - Conference: [Ancient City Ruby](https://www.youtube.com/user/Hashrocket)
-- Conference: [WindyCityRails](http://www.windycityrails.org/videos/2013/)
 - Conference: RailsConf, YouTube, search for "RailsConf XXXX", also search Confreaks
 
 ## Free Newsletters


### PR DESCRIPTION
Remove dead links to WindyCityRails. I searched the site and found 2 links:
- On the homepage (index.html) This is the link found by Joshua Needham in the LinkedIn post on the issue.

Before:
<img width="1065" height="765" alt="windycityrails-homepage-before" src="https://github.com/user-attachments/assets/7266b3ca-eb85-44ee-8cc2-69272a7b1032" />

After:
<img width="1024" height="770" alt="windycityrails-homepage-after" src="https://github.com/user-attachments/assets/5e98eadb-3833-4353-8da1-a1ff3b961838" />

- On the Resources page
Before:
<img width="834" height="317" alt="windycityrails-resources-before" src="https://github.com/user-attachments/assets/b3aa7923-cfaa-4821-96e2-45ff5e93ecb9" />

After:
<img width="882" height="272" alt="windycityrails-resources-after" src="https://github.com/user-attachments/assets/736dcdf2-959e-4170-8fb7-ac71dd2e4a7e" />



This change removes those links.